### PR TITLE
Make it harder to use incorrectly

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,11 +78,10 @@ Troubleshooting
 ### `cannot queue function in pool`
 
 If you're getting this error, then you're calling `start` too many times
-concurrently without waiting for the previous `start` call to resolve. Please
-read on - one of two things is happening:
+concurrently. Please read on - one of two things is happening:
 
-- you're using promise-pool in a way that will defeat its purpose
-- you're using promise-pool in an uncommon manner that works with its purpose (but might benefit from being refactored)
+- you're not waiting for the previous `start` call to resolve before calling `start` again
+- you're adding items to the pool in multiple places
 
 In the former case, you probably have code that looks like this:
 
@@ -159,8 +158,9 @@ async function startJobs() {
 }
 ```
 
-The other case is where you're using `promise-pool` in an unorthodox manner,
-where you'll need to use `maxPending`:
+The other case is where you're using `promise-pool` in multiple places, and
+thus you'll need to use `maxPending` to tell `promise-pool` that you know what
+you're doing:
 
 ```js
 async function initializeAllUsers() {

--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ backpressure to the imperative task producer.
 Requires a version of Node that supports [`async`][async]/[`await`][await].
 
 ```js
-const PromisePool = require('@mixmaxhq/promise-pool');
+import PromisePool from '@mixmaxhq/promise-pool';
 
 async function sample() {
   // Cap the concurrent function execution at 10.
-  const pool = new PromisePool(10);
+  const pool = new PromisePool({numConcurrent: 10});
 
   // Call an async function 1000000 times. The pool ensures that no more than
   // 10 will be executing at a time.
@@ -30,10 +30,14 @@ async function sample() {
   }
 
   // Wait for all the queued and running functions to finish.
-  await pool.flush();
+  const errors = await pool.flush();
 
   // We only log this once every result has been sent.
-  console.log('done');
+  if (errors.length) {
+    console.log('done with errors', errors);
+  } else {
+    console.log('done');
+  }
 }
 ```
 
@@ -59,11 +63,136 @@ $ npm i @mixmaxhq/promise-pool
 
 Changelog
 ---------
+
+* 1.2.0 Add `maxPending` option to avoid problematic usage (see new [Troubleshooting](#troubleshooting) section)
+
 * 1.1.1 Move `ava` and `ava-spec` to `devDependencies`.
 
 * 1.1.0 Adds transpilation so it can be used in Node 6 (and prior) environments.
 
 * 1.0.0 Initial release.
+
+Troubleshooting
+---------------
+
+### `cannot queue function in pool`
+
+If you're getting this error, then one of two things is happening:
+
+- you're using promise-pool in a way that will defeat its purpose
+- you're using promise-pool in an uncommon manner that works with its purpose (but might benefit from being refactored)
+
+In the former case, you probably have code that looks like this:
+
+```js
+import _ from 'lodash';
+import mongoist from 'mongoist';
+
+const db = mongoist(...);
+
+async function startJobs() {
+  const pool = new PromisePool({numConcurrent: 4});
+
+  // Pull in an array of users (high memory usage, poor performance
+  // characteristics due to loading all instead of streaming with something
+  // like promise-iterate).
+  const users = await db.users.findAsCursor().toArray();
+
+  // _.each doesn't wait on the promise returned by each invocation, so it
+  // won't apply backpressure to the loop in the manner pool.start expects.
+  _.each(users, async (user) => {
+    await pool.start(async () => {
+      await queue.publish(user);
+    });
+  });
+
+  await pool.flush();
+}
+```
+
+Instead, you need to use some iteration method that preserves backpressure, like the `for`-`of` loop:
+
+```js
+async function startJobs() {
+  const pool = new PromisePool({numConcurrent: 4});
+
+  // Still severely suboptimal.
+  const users = await db.users.findAsCursor().toArray();
+
+  for (const user of users) {
+    // Now the await applies to the `startJobs` async function instead of
+    // the anonymous async function.
+    await pool.start(async () => {
+      await queue.publish(user);
+    });
+  }
+
+  await pool.flush();
+}
+```
+
+Or even better, couple this with a call to `promise-iterate` to only load users as you need them:
+
+```js
+import {asyncIterate} from 'promise-iterate';
+
+async function startJobs() {
+  const pool = new PromisePool({numConcurrent: 4});
+
+  const users = await db.users.findAsCursor();
+
+  // promise-iterate correctly applies backpressure, and helpfully iterates
+  // the cursor without pulling in all results as an array.
+  await asyncIterate(users, async (user) => {
+    // The await still applies to the `startJobs` async function due to the
+    // behavior of promise-iterate.
+    await pool.start(async () => {
+      await queue.publish(user);
+    });
+  });
+
+  await pool.flush();
+}
+```
+
+The other case is where you're using `promise-pool` in an unorthodox manner,
+where you'll need to use `maxPending`:
+
+```js
+async function initializeAllUsers() {
+  const pool = new PromisePool({
+    numConcurrent: 4,
+
+    // Important: without this, we'll fail almost immediately after starting to
+    // kick off the first job and starting to send the first email.
+    maxPending: 2,
+  });
+
+  const users = await db.users.findAsCursor();
+
+  // Some cursor-compatible tee implementation.
+  const [usersA, usersB] = tee(users);
+
+  await Promise.all([
+    startJobs(pool, usersA),
+    sendEmails(pool, usersB),
+  });
+
+  await pool.flush();
+}
+
+async function startJobs(pool, users) {
+  await asyncIterate(users, async (user) => {
+    await queue.publish(user);
+  });
+}
+
+async function sendEmails(pool, users) {
+  await asyncIterate(users, async (user) => {
+    await sendEmail(user);
+  });
+}
+```
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ npm i @mixmaxhq/promise-pool
 Changelog
 ---------
 
-* 1.2.0 Add `maxPending` option to avoid problematic usage (see new [Troubleshooting](#troubleshooting) section)
+* 2.0.0 Add `maxPending` option to avoid problematic usage (see new [Troubleshooting](#troubleshooting) section)
 
 * 1.1.1 Move `ava` and `ava-spec` to `devDependencies`.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Troubleshooting
 
 ### `cannot queue function in pool`
 
-If you're getting this error, then one of two things is happening:
+If you're getting this error, then you're calling `start` too many times
+concurrently without waiting for the previous `start` call to resolve. Please
+read on - one of two things is happening:
 
 - you're using promise-pool in a way that will defeat its purpose
 - you're using promise-pool in an uncommon manner that works with its purpose (but might benefit from being refactored)

--- a/README.md
+++ b/README.md
@@ -183,13 +183,17 @@ async function initializeAllUsers() {
 
 async function startJobs(pool, users) {
   await asyncIterate(users, async (user) => {
-    await queue.publish(user);
+    await pool.start(async () => {
+      await queue.publish(user);
+    });
   });
 }
 
 async function sendEmails(pool, users) {
   await asyncIterate(users, async (user) => {
-    await sendEmail(user);
+    await pool.start(async () => {
+      await sendEmail(user);
+    });
   });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ async function startJobs() {
 
   // _.each doesn't wait on the promise returned by each invocation, so it
   // won't apply backpressure to the loop in the manner pool.start expects.
+  // This will also not catch any error raised by pool.start, and will cause
+  // recent versions of Node to crash due to an unhandled rejection!
   _.each(users, async (user) => {
     await pool.start(async () => {
       await queue.publish(user);

--- a/src/index.js
+++ b/src/index.js
@@ -48,7 +48,8 @@ class PromisePool extends Emitter {
 
     if (this._numActive >= this._numConcurrent) {
       if (this._pending.length >= this._maxPending) {
-        throw new Error('cannot queue function in pool: the pool is likely being used in a manner that does not propagate backpressure');
+        // the pool is likely being used in a manner that does not propagate backpressure
+        throw new Error('cannot queue function in pool: please read the documentation');
       }
       const task = deferred();
       this._pending.push(task.defer());

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ class PromisePool extends Emitter {
     if (this._numActive >= this._numConcurrent) {
       if (this._pending.length >= this._maxPending) {
         // the pool is likely being used in a manner that does not propagate backpressure
-        throw new Error('cannot queue function in pool: please read the documentation');
+        throw new Error('cannot queue function in pool, too many pending invocations: please see the documentation');
       }
       const task = deferred();
       this._pending.push(task.defer());

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ class PromisePool extends Emitter {
     if (this._numActive >= this._numConcurrent) {
       if (this._pending.length >= this._maxPending) {
         // the pool is likely being used in a manner that does not propagate backpressure
-        throw new Error('cannot queue function in pool, too many pending invocations: please see the documentation');
+        throw new Error('too many pending invocations: please look for "cannot queue function in pool" in the documentation');
       }
       const task = deferred();
       this._pending.push(task.defer());

--- a/test/index.js
+++ b/test/index.js
@@ -123,7 +123,7 @@ describe('PromisePool', (it) => {
     t.is(hits, 9);
   });
 
-  it('should disallow poor usage', async (t) => {
+  it('should guard against lack of backpressure', async (t) => {
     const array = [1, 2, 3, 4, 5];
 
     const pool = new PromisePool(2);
@@ -138,7 +138,7 @@ describe('PromisePool', (it) => {
     await t.throws(Promise.all(res), /cannot queue function in pool/);
   });
 
-  it('should allow strange usage', async (t) => {
+  it('should allow more than one pending start', async (t) => {
     const array = [1, 2, 3, 4, 5];
 
     const pool = new PromisePool({numConcurrent: 2, maxPending: 2});
@@ -152,7 +152,7 @@ describe('PromisePool', (it) => {
     await t.notThrows(Promise.all([useArray(), useArray()]));
   });
 
-  it('should restrict strange usage', async (t) => {
+  it('should restrict excessive pending usage', async (t) => {
     const array = [1, 2, 3, 4, 5];
 
     const pool = new PromisePool({numConcurrent: 2, maxPending: 2});

--- a/test/index.js
+++ b/test/index.js
@@ -122,6 +122,49 @@ describe('PromisePool', (it) => {
 
     t.is(hits, 9);
   });
+
+  it('should disallow poor usage', async (t) => {
+    const array = [1, 2, 3, 4, 5];
+
+    const pool = new PromisePool(2);
+
+    const res = [];
+
+    // It doesn't really matter where the error happens, just that it happens.
+    res.push((async () => {
+      array.forEach(() => res.push(pool.start(async () => {})));
+    })());
+
+    await t.throws(Promise.all(res), /cannot queue function in pool/);
+  });
+
+  it('should allow strange usage', async (t) => {
+    const array = [1, 2, 3, 4, 5];
+
+    const pool = new PromisePool({numConcurrent: 2, maxPending: 2});
+
+    async function useArray() {
+      for (const item of array) {
+        await pool.start(async () => {}, item);
+      }
+    }
+
+    await t.notThrows(Promise.all([useArray(), useArray()]));
+  });
+
+  it('should restrict strange usage', async (t) => {
+    const array = [1, 2, 3, 4, 5];
+
+    const pool = new PromisePool({numConcurrent: 2, maxPending: 2});
+
+    async function useArray() {
+      for (const item of array) {
+        await pool.start(async () => {}, item);
+      }
+    }
+
+    await t.throws(Promise.all([useArray(), useArray(), useArray()]), /cannot queue function in pool/);
+  });
 });
 
 function immediately() {


### PR DESCRIPTION
Yes, ideally the API would make it self-evident as to how you should use promise-pool, but the reality is that our developers are misusing the module.